### PR TITLE
Bug Fix: logging response data is not possible

### DIFF
--- a/Source/NetworkActivityLogger.swift
+++ b/Source/NetworkActivityLogger.swift
@@ -185,21 +185,6 @@ public class NetworkActivityLogger {
                 for (key, value) in response.allHeaderFields {
                     print("\(key): \(value)")
                 }
-                
-                guard let data = sessionDelegate[task]?.delegate.data else { break }
-                    
-                do {
-                    let jsonObject = try JSONSerialization.jsonObject(with: data, options: .mutableContainers)
-                    let prettyData = try JSONSerialization.data(withJSONObject: jsonObject, options: .prettyPrinted)
-                    
-                    if let prettyString = String(data: prettyData, encoding: .utf8) {
-                        print(prettyString)
-                    }
-                } catch {
-                    if let string = NSString(data: data, encoding: String.Encoding.utf8.rawValue) {
-                        print(string)
-                    }
-                }
             case .info:
                 print("\(String(response.statusCode)) '\(requestURL.absoluteString)' [\(String(format: "%.04f", elapsedTime)) s]")
             default:


### PR DESCRIPTION
Bug Fix: logging response data is not possible because TaskDelegate.data is now internal in Alamofire

There is no way to access the response data in the function networkRequestDidComplete(), because Alamofire has changed the data variable of the TaskDelegate to internal, meaning only other classes in the Alamofire module can access it. Since this logger is in it's own module, it cannot access this variable this way and thus not print out the response data when the log level is set to debug.

A workaround would be to use sessionDelegate[task].responseData {...}, but this would just enqueue the closure and log messages would be out of order – first the request would be logged, followed by the answer and then somewhen later the response data. This is not very practical, so the recommended approach is to merely log calls and introspect any returned data in the respective code.

Because of that, the code to print the response was removed.