### PR TITLE
Share schemes

### DIFF
--- a/AlamofireNetworkActivityLogger.xcodeproj/xcshareddata/xcschemes/AlamofireNetworkActivityLogger iOS.xcscheme
+++ b/AlamofireNetworkActivityLogger.xcodeproj/xcshareddata/xcschemes/AlamofireNetworkActivityLogger iOS.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0820"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AB2A9A2A1DBB4600004FC92E"
+               BuildableName = "AlamofireNetworkActivityLogger.framework"
+               BlueprintName = "AlamofireNetworkActivityLogger iOS"
+               ReferencedContainer = "container:AlamofireNetworkActivityLogger.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AB2A9A2A1DBB4600004FC92E"
+            BuildableName = "AlamofireNetworkActivityLogger.framework"
+            BlueprintName = "AlamofireNetworkActivityLogger iOS"
+            ReferencedContainer = "container:AlamofireNetworkActivityLogger.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AB2A9A2A1DBB4600004FC92E"
+            BuildableName = "AlamofireNetworkActivityLogger.framework"
+            BlueprintName = "AlamofireNetworkActivityLogger iOS"
+            ReferencedContainer = "container:AlamofireNetworkActivityLogger.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/AlamofireNetworkActivityLogger.xcodeproj/xcshareddata/xcschemes/AlamofireNetworkActivityLogger macOS.xcscheme
+++ b/AlamofireNetworkActivityLogger.xcodeproj/xcshareddata/xcschemes/AlamofireNetworkActivityLogger macOS.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0820"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AB2A9A5C1DBB5066004FC92E"
+               BuildableName = "AlamofireNetworkActivityLogger.framework"
+               BlueprintName = "AlamofireNetworkActivityLogger macOS"
+               ReferencedContainer = "container:AlamofireNetworkActivityLogger.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AB2A9A5C1DBB5066004FC92E"
+            BuildableName = "AlamofireNetworkActivityLogger.framework"
+            BlueprintName = "AlamofireNetworkActivityLogger macOS"
+            ReferencedContainer = "container:AlamofireNetworkActivityLogger.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AB2A9A5C1DBB5066004FC92E"
+            BuildableName = "AlamofireNetworkActivityLogger.framework"
+            BlueprintName = "AlamofireNetworkActivityLogger macOS"
+            ReferencedContainer = "container:AlamofireNetworkActivityLogger.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/AlamofireNetworkActivityLogger.xcodeproj/xcshareddata/xcschemes/AlamofireNetworkActivityLogger tvOS.xcscheme
+++ b/AlamofireNetworkActivityLogger.xcodeproj/xcshareddata/xcschemes/AlamofireNetworkActivityLogger tvOS.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0820"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AB2A9A691DBB5119004FC92E"
+               BuildableName = "AlamofireNetworkActivityLogger.framework"
+               BlueprintName = "AlamofireNetworkActivityLogger tvOS"
+               ReferencedContainer = "container:AlamofireNetworkActivityLogger.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AB2A9A691DBB5119004FC92E"
+            BuildableName = "AlamofireNetworkActivityLogger.framework"
+            BlueprintName = "AlamofireNetworkActivityLogger tvOS"
+            ReferencedContainer = "container:AlamofireNetworkActivityLogger.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AB2A9A691DBB5119004FC92E"
+            BuildableName = "AlamofireNetworkActivityLogger.framework"
+            BlueprintName = "AlamofireNetworkActivityLogger tvOS"
+            ReferencedContainer = "container:AlamofireNetworkActivityLogger.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/AlamofireNetworkActivityLogger.xcodeproj/xcshareddata/xcschemes/AlamofireNetworkActivityLogger watchOS.xcscheme
+++ b/AlamofireNetworkActivityLogger.xcodeproj/xcshareddata/xcschemes/AlamofireNetworkActivityLogger watchOS.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0820"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AB2A9A761DBB512B004FC92E"
+               BuildableName = "AlamofireNetworkActivityLogger.framework"
+               BlueprintName = "AlamofireNetworkActivityLogger watchOS"
+               ReferencedContainer = "container:AlamofireNetworkActivityLogger.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AB2A9A761DBB512B004FC92E"
+            BuildableName = "AlamofireNetworkActivityLogger.framework"
+            BlueprintName = "AlamofireNetworkActivityLogger watchOS"
+            ReferencedContainer = "container:AlamofireNetworkActivityLogger.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AB2A9A761DBB512B004FC92E"
+            BuildableName = "AlamofireNetworkActivityLogger.framework"
+            BlueprintName = "AlamofireNetworkActivityLogger watchOS"
+            ReferencedContainer = "container:AlamofireNetworkActivityLogger.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "Alamofire/Alamofire" ~> 4.2
+github "Alamofire/Alamofire" ~> 4.4

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "Alamofire/Alamofire" "4.0.1"
+github "Alamofire/Alamofire" "4.4.0"


### PR DESCRIPTION
Share framework schemes to fix issue https://github.com/konkab/AlamofireNetworkActivityLogger/issues/3 which doesn't allow to include the framework using `Carthage`.

Update `Alamofire` to version 4.4, since the logger reads a property `internal` in version 4.2, and was not compiling unless the version is updated making this property `public`.

@konkab why are you adding the `Alamofire` framework as a submodule? I'd just add it to the `Cartfile` (what is already done too) and ignore the downloaded framework, I see no need for the submodule. If you want I can make this change.