### PR TITLE
Style logs

### DIFF
--- a/Source/NetworkActivityLogger.swift
+++ b/Source/NetworkActivityLogger.swift
@@ -120,6 +120,8 @@ public class NetworkActivityLogger {
         
         startDates[task] = Date()
         
+        logDivider()
+        
         switch level {
         case .debug:
             print("\(httpMethod) '\(requestURL.absoluteString)':")
@@ -161,6 +163,8 @@ public class NetworkActivityLogger {
             elapsedTime = Date().timeIntervalSince(startDate)
             startDates[task] = nil
         }
+        
+        logDivider()
         
         if let error = task.error {
             switch level {
@@ -207,4 +211,12 @@ public class NetworkActivityLogger {
             }
         }
     }
+}
+
+private extension NetworkActivityLogger {
+    
+    func logDivider() {
+        print("---------------------")
+    }
+    
 }

--- a/Source/NetworkActivityLogger.swift
+++ b/Source/NetworkActivityLogger.swift
@@ -127,9 +127,7 @@ public class NetworkActivityLogger {
             print("\(httpMethod) '\(requestURL.absoluteString)':")
             
             if let httpHeadersFields = request.allHTTPHeaderFields {
-                for (key, value) in httpHeadersFields {
-                    print("\(key): \(value)")
-                }
+                logHeaders(headers: httpHeadersFields)
             }
             
             if let httpBody = request.httpBody, let httpBodyString = String(data: httpBody, encoding: .utf8) {
@@ -186,9 +184,7 @@ public class NetworkActivityLogger {
             case .debug:
                 print("\(String(response.statusCode)) '\(requestURL.absoluteString)' [\(String(format: "%.04f", elapsedTime)) s]:")
                 
-                for (key, value) in response.allHeaderFields {
-                    print("\(key): \(value)")
-                }
+                logHeaders(headers: response.allHeaderFields)
                 
                 guard let data = sessionDelegate[task]?.delegate.data else { break }
                     
@@ -217,6 +213,14 @@ private extension NetworkActivityLogger {
     
     func logDivider() {
         print("---------------------")
+    }
+    
+    func logHeaders(headers: [AnyHashable : Any]) {
+        print("Headers: [")
+        for (key, value) in headers {
+            print("  \(key) : \(value)")
+        }
+        print("]")
     }
     
 }


### PR DESCRIPTION
Style logs:

- Print headers in a private function to avoid repeating code.
- Print a separator among requests / responses to view easily when each starts / ends.

Example of output:

```
---------------------
GET 'https://github.com/konkab/AlamofireNetworkActivityLogger':
Headers: [
  Content-Type : application/x-www-form-urlencoded; charset=utf-8
  Authorization : XXXX
]
---------------------
200 'https://github.com/konkab/AlamofireNetworkActivityLogger' [1.2180 s]:
Headers: [
  Cache-Control : max-age=0, private, must-revalidate
  ...
  Server : Cowboy
]
[
  {
  ...
  }
]
```