### PR TITLE
Add Support for Swift Package Manager of Release 2.4.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,40 @@
+// swift-tools-version:5.1
+//
+//  Package.swift
+//
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2016 Konstantin Kabanov
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+
+import PackageDescription
+
+let package = Package(name: "AlamofireNetworkActivityLogger",
+                      platforms: [.iOS(.v10),
+                                  .macOS(.v10_12),
+                                  .tvOS(.v10),
+                                  .watchOS(.v3)],
+                      products: [.library(name: "AlamofireNetworkActivityLogger", targets: ["AlamofireNetworkActivityLogger"])],
+                      dependencies: [.package(url: "https://github.com/Alamofire/Alamofire.git",
+                                              from: "4.8.0")],
+                      targets: [.target(name: "AlamofireNetworkActivityLogger",
+                                        dependencies: ["Alamofire"],
+                                        path: "Source")],
+                      swiftLanguageVersions: [.v5])


### PR DESCRIPTION
We want to switch to SPM on a project, that is still using Alamofire 4.9.x. SPM Support for AlamofireNetwokActivityLogger is only introduced starting Version 3.0.0 which requires Alamofire 5.x.x.

This PR adds a Package.swift to a branch based on Release 2.4.0

Obviously, merging that to master wouldn't make sense. @konkab could you create a branch based on Tag 2.4.0 and merge that into it?